### PR TITLE
RFC: Tag matching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,4 +59,15 @@ mod tests {
         assert_eq!(m, true);
 
     }
+
+    #[test]
+    fn simple_tag_match_with_public_member() {
+        let tlv = Tlv::new(Tag::try_from(10).unwrap(), vec![0x0, 0x1]).unwrap();
+
+        let m = match tlv.tag() {
+            Tag(10) => true,
+            _ => false
+        };
+        assert_eq!(m, true);
+    }
 }

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -49,7 +49,7 @@ use crate::{Result, TlvError};
 /// #
 /// ```
 #[derive(PartialEq, Debug, Clone, Copy)]
-pub struct Tag(u8);
+pub struct Tag(pub u8);
 
 /// Value for SIMPLE-TLV data as defined in [ISO7816-4].
 /// > The value field consists of N consecutive bytes.


### PR DESCRIPTION
There's currently no simple way (or at least I haven't found) to do pattern matching based on Tag values.