### PR TITLE
Adaptations to handle PIV BER-TLV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "Readme.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
+piv = []
 
 
 [dependencies]

--- a/src/ber/mod.rs
+++ b/src/ber/mod.rs
@@ -1,10 +1,15 @@
 //! This module provides tools and utilities for handling BER-TLV data as
 //! defined in [ISO7816-4][iso7816-4].
 //!
+//! In PIV, data object's inner tag does not necessarily follow BER-TLV
+//! requirement (see [NIST specification, Section
+//! 4.1][NIST-SP-800-73-4]). When using the `piv` feature, the
+//! consistency of the tag class with the actual value is not checked.
 //!
 //!
 //!
 //! [iso7816-4]: https://www.iso.org/standard/54550.html
+//! [NIST-SP-800-73-4](https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-73-4.pdf)
 
 // internal organization
 mod tag;

--- a/src/ber/tag.rs
+++ b/src/ber/tag.rs
@@ -86,6 +86,7 @@ pub struct Tag {
 
 impl Tag {
     const CLASS_MASK: u8 = 0b1100_0000;
+    #[cfg(not(feature = "piv"))]
     const CONSTRUCTED_MASK: u8 = 0b0010_0000;
     const VALUE_MASK: u8 = 0b0001_1111;
     const MORE_BYTES_MASK: u8 = 0b1000_0000;
@@ -132,6 +133,8 @@ impl Tag {
     /// > - The value 0 indicates a primitive encoding of the data object, i.e., the value field is not encoded in BER - TLV .
     /// > - The value 1 indicates a constructed encoding of the data object, i.e., the value field is encoded in BER - TLV
     ///
+    /// Using the `piv` feature disables this.
+    ///
     /// # Example
     /// ```rust
     /// use std::convert::TryFrom;
@@ -148,6 +151,7 @@ impl Tag {
     /// # }
     /// #
     /// ```
+    #[cfg(not(feature = "piv"))]
     #[must_use]
     pub fn is_constructed(&self) -> bool {
         !matches!(self.raw[3 - self.len] & Self::CONSTRUCTED_MASK, 0)
@@ -205,11 +209,16 @@ impl fmt::Debug for Tag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let t = [0, self.raw[0], self.raw[1], self.raw[2]];
         let as_int: u32 = u32::from_be_bytes(t);
+
+        #[cfg(not(feature = "piv"))]
         let constructed = if self.is_constructed() {
             "Contructed"
         } else {
             "Primitive"
         };
+        #[cfg(feature = "piv")]
+        let constructed = "";
+
         write!(f, "Tag {:x} ({:?}; {})", as_int, self.class(), constructed)
     }
 }


### PR DESCRIPTION
In [the NIST standard for Personal Identity Verification (PIV)](https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-73-4.pdf), BER-TLV structures are used. However, the standard specifies the following:

>The PIV data objects are BER-TLV objects encoded as per [ISO8825], except that tag values of the PIV data object’s inner tag assignments do not conform to BER-TLV requirements.13 This is due to the need to accommodate legacy tags inherited from [GSC-IS].

In particular, it means that it exists structures where the TLV should be of type primitive but the associated tag have the "constructed bit" set, eg. the GUID field of the CHUID structure having `0x34` as tag but being primitive (Table 9, page 40 of [NIST SP 800-73-4](https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-73-4.pdf)).

In order to not restart a library from scratch and use this crate to manipulate TLV in the context of PIV, I implemented a new opt-in feature: `piv`. This feature basically disables the consistency check of the tag's constructed bit with the actual value passed while constructing a TLV object. Not being able to tell if a TLV is constructed or primitive makes the recursive parsing impossible. Thus, I chose to only implement the parsing of a structure with maximum depth two. I used conditional compilation extensively to avoid modifying the behaviour or interfaces of the library when the `piv` feature is not enabled.

Since I am fairly new to Rust programming, let me know if it can be merged in this crate or if you see a better approach to solve this problem.