### PR TITLE
More persmissive tag validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso7816-tlv"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Julien Kowalski <julien.kowalski@ercom.fr>"]
 edition = "2018"
 license = "ISC"

--- a/src/ber/tag.rs
+++ b/src/ber/tag.rs
@@ -110,7 +110,7 @@ impl Tag {
     /// let tag = Tag::try_from("7f22")?;
     /// assert_eq!(2, tag.len_as_bytes());  
     ///
-    /// let tag = Tag::try_from("7f8022")?;
+    /// let tag = Tag::try_from("7f8122")?;
     /// assert_eq!(3, tag.len_as_bytes());
     ///
     /// let tag = Tag::try_from("5fff22")?;

--- a/src/ber/tag.rs
+++ b/src/ber/tag.rs
@@ -47,7 +47,7 @@ impl From<u8> for Class {
 /// [str]:https://doc.rust-lang.org/std/str/
 ///
 /// Tags are now imported in a more permissivie way.
-/// Invalid tags in ISO7816 meaning can be checked, see [Self::iso7816_compliant]
+/// Invalid tags in ISO7816 meaning can be checked, see [`Self::iso7816_compliant`]
 ///
 /// # Example
 /// ```rust
@@ -174,6 +174,7 @@ impl Tag {
     /// # Ok(())
     /// # }
     /// #
+    #[must_use]
     pub fn iso7816_compliant(&self) -> bool {
         let first_byte_ok = if self.len == 1 {
             (self.raw[2] & Self::VALUE_MASK) != Self::VALUE_MASK
@@ -186,11 +187,7 @@ impl Tag {
             2 => {
                 // In two-byte tag fields, the second byte consists of bit 8 set to 0 and bits 7 to 1 encoding a number greater
                 // than thirty. The second byte is valued from '1F' to '7F; the tag number is from 31 to 127
-                if self.raw[2] < 0x1F_u8 || self.raw[2] > 0x7F_u8 {
-                    false
-                } else {
-                    true
-                }
+                !(self.raw[2] < 0x1F_u8 || self.raw[2] > 0x7F_u8)
             }
             3 => {
                 // The second byte is valued from '81' to 'FF'
@@ -424,7 +421,7 @@ mod tests {
 
     #[test]
     fn issue_14() -> Result<()> {
-        let testcases = [0x7f1e, 0x7f8001, 0x7f00, 0x9f1e, 0x9f00];
+        let testcases = [0x7f1e, 0x007f_8001, 0x7f00, 0x9f1e, 0x9f00];
         for v in testcases {
             let t = Tag::try_from(v)?;
             assert!(!t.iso7816_compliant());

--- a/src/ber/tag.rs
+++ b/src/ber/tag.rs
@@ -271,7 +271,7 @@ impl TryFrom<u64> for Tag {
         }
 
         if len > 1 {
-            match bytes[3 - len] {
+            match bytes[1] {
                 0x00 | 0x1E | 0x80 => return Err(TlvError::InvalidInput),
                 _ => (),
             }
@@ -374,6 +374,16 @@ mod tests {
         assert_eq!(2, t.len_as_bytes());
 
         Ok(())
+    }
+
+    #[test]
+    fn issue_14() {
+        assert_eq!(Err(TlvError::InvalidInput), Tag::try_from(0x7f1e01));
+        assert_eq!(Err(TlvError::InvalidInput), Tag::try_from(0x7f8001));
+        assert_eq!(Err(TlvError::InvalidInput), Tag::try_from(0x7f0001));
+        assert_eq!(Err(TlvError::InvalidInput), Tag::try_from(0x9f1e));
+        assert_eq!(Err(TlvError::InvalidInput), Tag::try_from(0x9f00));
+        assert_eq!(Err(TlvError::InvalidInput), Tag::try_from(0x9f80));
     }
 
     #[test]

--- a/src/ber/tlv.rs
+++ b/src/ber/tlv.rs
@@ -247,7 +247,7 @@ impl fmt::Display for Tlv {
         match &self.value {
             Value::Primitive(e) => {
                 for x in e {
-                    write!(f, "{:02X}", x)?;
+                    write!(f, "{x:02X}")?;
                 }
             }
             Value::Constructed(e) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ impl fmt::Display for TlvError {
       Self::Inconsistant => "Inconsistant (tag, value) pair",
       Self::InvalidLength => "Read invalid length value",
     };
-    write!(f, "{}", s)
+    write!(f, "{s}")
   }
 }
 

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -327,7 +327,7 @@ mod tests {
             let v: Value = (0..v_len).map(|_| rng.next_u32() as u8).collect();
             let tlv = Tlv::new(Tag::try_from(r)?, v.clone())?;
             let ser = tlv.to_vec();
-            let tlv_2 = Tlv::from_bytes(&*ser)?;
+            let tlv_2 = Tlv::from_bytes(&ser)?;
             assert_eq!(tlv, tlv_2);
 
             assert_eq!(r, tlv.tag().into());


### PR DESCRIPTION
Be more permissive for tag reading.
ISO7816 compliance can be checked after

Fixes Issue #14  