### PR TITLE
Add std as feature so it can be turned on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "Readme.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-
+std = []
 
 [dependencies]
 untrusted = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 // otherwise cargo doc fails with
 // error: no global memory allocator found but one is required; link to std or add #[global_allocator] to
 // a static item that implements the GlobalAlloc trait.
-#![cfg_attr(not(doc), no_std)]
+#![cfg_attr(all(not(doc), not(feature = "std")), no_std)]
 
 // use custom allocator for tests
 #[cfg(test)]


### PR DESCRIPTION
There is no way (at least to my understanding) to turn `std` on for the crate. This solves this by adding it as a feature. I am unsure whether or not `std` should be turned on by default so I just left is as opt-in for now.