### PR TITLE
Add `simple::Tag::try_from_u8` as const alternative to `TryFrom<u8>`

### DIFF
--- a/src/simple.rs
+++ b/src/simple.rs
@@ -51,6 +51,32 @@ use crate::{Result, TlvError};
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub struct Tag(u8);
 
+impl Tag {
+    /// Tries to convert a `u8` into a `Tag`. This is equivalent to the
+    /// [`TryFrom`] impl for `u8`, except that this fn is const and can be used
+    /// in some contexts that `TryFrom` cannot be used in, for example for
+    /// defining constants:
+    ///
+    /// ```
+    /// use iso7816_tlv::simple::Tag;
+    ///
+    /// const SOME_TAG_CONSTANT: Tag = match Tag::try_from_u8(0x42) {
+    ///     Ok(tag) => tag,
+    ///     Err(e) => panic!(),
+    /// };
+    /// ```
+    ///
+    /// # Errors
+    /// This method returns `Err(TlvError::InvalidInput)` if `v` is not a legal
+    /// tag (e.g., if v is `0x00` or `0xFF`).
+    pub const fn try_from_u8(v: u8) -> Result<Self> {
+        match v {
+            0x00 | 0xFF => Err(TlvError::InvalidInput),
+            _ => Ok(Self(v)),
+        }
+    }
+}
+
 /// Value for SIMPLE-TLV data as defined in [ISO7816-4].
 /// > The value field consists of N consecutive bytes.
 /// > N may be zero.
@@ -79,10 +105,7 @@ impl Into<u8> for Tag {
 impl TryFrom<u8> for Tag {
     type Error = TlvError;
     fn try_from(v: u8) -> Result<Self> {
-        match v {
-            0x00 | 0xFF => Err(TlvError::InvalidInput),
-            _ => Ok(Self(v)),
-        }
+        Self::try_from_u8(v)
     }
 }
 


### PR DESCRIPTION
This is equivalent to the `TryFrom` impl for `u8`, except that this fn is const and can be used in some contexts that `TryFrom` cannot be used in, for example for defining constants:

```
use iso7816_tlv::simple::Tag;

const SOME_TAG_CONSTANT: Tag = match Tag::try_from_u8(0x42) {
    Ok(tag) => tag,
    Err(e) => panic!(),
 };
```

Note: While a similar fn for u64 on `ber::Tag` might be useful, I haven't implemented it for multiple reasons:
1. `impl TryFrom<u64> for ber::Tag` is *much* more complicated than `impl TryFrom<u8> for simple::Tag`, making it const is non-trivial
2. Constructing `ber::Tag`s from `u64` doesn't seem to be the best interface to me anyway - it might be nicer to instead have `fn new(class: Class, tag_number: u32)` (and have this constructor receive a tag number instead of the binary pattern that is the serialized representation of the tag)
3. I only use SIMPLE-TLV and need a const way to construct simple tags, BER is not necessary for my use case, which, to be honest, is my main reason :)
